### PR TITLE
Make sure WeakMap is available before use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Bug Fixes
+- Make sure WeakMap is available before use
+
 ## v1.0.2 - 2017-10-05
 - Improve performance by reducing calls to Object.getOwnPropertyDescriptor
 

--- a/src/isWeakMapAvailable.js
+++ b/src/isWeakMapAvailable.js
@@ -1,0 +1,4 @@
+// @flow
+
+// TODO(dounan): inline this when flow stops being buggy
+export default typeof WeakMap !== "undefined";


### PR DESCRIPTION
Before this PR, we were creating `WeakMap` without making sure the feature exists.